### PR TITLE
Updated git ignore to ignore word vector embeddings data and story_graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 __pycache__/
 bot_engine/models/
+bot_engine/data/embeddings/
+bot_engine/story_graph.dot
 
 # Environments
 .env


### PR DESCRIPTION
This is in the same vein as the other stuff we're already ignoring. 

Embeddings is full of huge files, that we certainly don't want to commit (much of it auto generated) and story_graph is auto generated every time we do interactive_training.