### PR TITLE
Added components to print state

### DIFF
--- a/bot_engine/components/util_components.py
+++ b/bot_engine/components/util_components.py
@@ -1,0 +1,9 @@
+from rasa_nlu.components import Component
+
+class ProcessingReporter(Component):
+
+    def train(self, training_data, cfg, **kwargs):
+        pass
+
+    def process(self, message, **kwargs):
+        print(message.data["text_features"].shape)


### PR DESCRIPTION
I added util_components, which are intended to be components that are added to a pipeline if you want to print information about message state. 

Currently I only have one example, ProcessingReporter, which prints the shape of any features it gets as input, but surely we could expand on this template.

I already used ProcessingReporter to find out that TfIdCharwordFeaturizer was deleting previous features it was getting.